### PR TITLE
keys, certs and cacerts as strings

### DIFF
--- a/t/01-create-idp.t
+++ b/t/01-create-idp.t
@@ -1,5 +1,6 @@
 use Test::More;
 use Net::SAML2;
+use File::Slurp qw(read_file);
 
 my $xml = <<XML;
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -66,5 +67,22 @@ ok($idp->entityid eq 'http://sso.dev.venda.com/opensso');
 
 ok('urn:oasis:names:tc:SAML:2.0:nameid-format:transient' eq $idp->format('transient'));
 ok('urn:oasis:names:tc:SAML:2.0:nameid-format:persistent' eq $idp->format);
+
+# Test with passing the cacert as a string
+my $cacert_string = read_file( 't/cacert.pem' );
+ok($cacert_string);
+
+my $idp2 = Net::SAML2::IdP->new_from_xml( xml => $xml, cacert => $cacert_string, certs_as_string => 1 );
+ok($idp2);
+
+ok($idp2->sso_url($idp2->binding('redirect')));
+ok($idp2->slo_url($idp2->binding('redirect')));
+ok($idp2->art_url($idp2->binding('soap')));
+
+ok($idp2->cert('signing'));
+ok($idp2->entityid eq 'http://sso.dev.venda.com/opensso');
+
+ok('urn:oasis:names:tc:SAML:2.0:nameid-format:transient' eq $idp2->format('transient'));
+ok('urn:oasis:names:tc:SAML:2.0:nameid-format:persistent' eq $idp2->format);
 
 done_testing;

--- a/t/02-create-sp.t
+++ b/t/02-create-sp.t
@@ -1,12 +1,17 @@
 use Test::More;
 use Net::SAML2;
+use File::Slurp qw(read_file);
+
+$cert = 't/sign-nopw-cert.pem';
+$key  = 't/sign-nopw-cert.pem';
+$cacert = 't/cacert.pem';
 
 my $sp = Net::SAML2::SP->new(
         id               => 'http://localhost:3000',
         url              => 'http://localhost:3000',
-        cert             => 't/sign-nopw-cert.pem',
-        key              => 't/sign-nopw-cert.pem',
-        cacert           => 't/cacert.pem',
+        cert             => $cert,
+        key              => $key,
+        cacert           => $cacert,
         org_name         => 'Test',
         org_display_name => 'Test',
         org_contact      => 'test@example.com',
@@ -20,5 +25,32 @@ $xpath->set_namespace('md', 'urn:oasis:names:tc:SAML:2.0:metadata');
 
 my @ssos = $xpath->findnodes('//md:EntityDescriptor/md:SPSSODescriptor/md:AssertionConsumerService');
 ok($ssos[0]->getAttribute('Binding') eq 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST');
+
+# repeat tests for text cert files
+$cert_text = read_file($cert);
+$key_text = read_file($key);
+$cacert_text = read_file($cacert);
+
+my $sp_text = Net::SAML2::SP->new(
+        id               => 'http://localhost:3000',
+        url              => 'http://localhost:3000',
+        cert             => $cert_text,
+        key              => $key_text,
+        cacert           => $cacert_text,
+        org_name         => 'Test',
+        org_display_name => 'Test',
+        org_contact      => 'test@example.com',
+        certs_as_string  => 1,
+);
+ok($sp_text);
+ok($sp_text->metadata);
+
+my $xml = $sp_text->metadata;
+my $xpath = XML::XPath->new( xml => $xml );
+$xpath->set_namespace('md', 'urn:oasis:names:tc:SAML:2.0:metadata');
+
+my @ssos = $xpath->findnodes('//md:EntityDescriptor/md:SPSSODescriptor/md:AssertionConsumerService');
+ok($ssos[0]->getAttribute('Binding') eq 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST');
+
 
 done_testing;

--- a/t/05-soap-binding.t
+++ b/t/05-soap-binding.t
@@ -3,15 +3,19 @@ use strict;
 use warnings;
 use Net::SAML2;
 use MIME::Base64;
-use File::Slurp;
+use File::Slurp qw( read_file );
 use LWP::UserAgent;
+
+my $cert = 't/sign-nopw-cert.pem';
+my $key = 't/sign-nopw-cert.pem';
+my $cacert = 't/cacert.pem';
 
 my $sp = Net::SAML2::SP->new(
         id               => 'http://localhost:3000',
         url              => 'http://localhost:3000',
-        cert             => 't/sign-nopw-cert.pem',
-        key              => 't/sign-nopw-cert.pem',
-        cacert           => 't/cacert.pem',
+        cert             => $cert,
+        key              => $key,
+        cacert           => $cacert,
         org_name         => 'Test',
         org_display_name => 'Test',
         org_contact      => 'test@example.com',
@@ -20,8 +24,10 @@ ok($sp);
 
 my $metadata = read_file('t/idp-metadata.xml');
 ok($metadata);
+
 my $idp = Net::SAML2::IdP->new_from_xml( xml => $metadata, cacert => 't/cacert.pem' );
 ok($idp);
+
 my $slo_url = $idp->slo_url($idp->binding('soap'));
 ok($slo_url);
 my $idp_cert = $idp->cert('signing');
@@ -55,5 +61,65 @@ ok($soaped_request);
 isa_ok($soaped_request, 'Net::SAML2::Protocol::LogoutRequest');
 ok($soaped_request->session eq $request->session);
 ok($soaped_request->nameid eq $request->nameid);
+
+# Repeat Tests for certs as strings
+
+my $cert_text = read_file($cert);
+my $key_text = read_file($key);
+my $cacert_text = read_file($cacert);
+
+my $sp_text = Net::SAML2::SP->new(
+        id               => 'http://localhost:3000',
+        url              => 'http://localhost:3000',
+        cert             => $cert,
+        key              => $key,
+        cacert           => $cacert,
+        org_name         => 'Test',
+        org_display_name => 'Test',
+        org_contact      => 'test@example.com',
+);
+ok($sp_text);
+
+$metadata = read_file('t/idp-metadata.xml');
+ok($metadata);
+
+my $idp_text = Net::SAML2::IdP->new_from_xml(
+                    xml             => $metadata,
+                    cacert          => $cacert_text,
+                    certs_as_string => 1 );
+ok($idp_text);
+
+my $slo_url_text = $idp->slo_url($idp_text->binding('soap'));
+ok($slo_url_text);
+my $idp_cert_text = $idp_text->cert('signing');
+ok($idp_cert_text);
+
+$nameid = 'user-to-log-out';
+$session = 'session-to-log-out';
+
+my $request_text = $sp_text->logout_request(
+        $idp_text->entityid, $nameid, $idp_text->format('persistent'), $session,
+);
+ok($request_text);
+my $request_xml_text = $request_text->as_xml;
+ok($request_xml_text);
+
+my $soap_text = $sp_text->soap_binding($ua, $slo_url_text, $idp_cert_text);
+ok($soap_text);
+
+my $soap_req_text = $soap_text->create_soap_envelope($request_xml_text);
+ok($soap_req_text);
+
+my ($subject_text, $xml_text) = $soap_text->handle_request($soap_req_text);
+ok($subject_text);
+ok($xml_text);
+
+my $soaped_request_text = Net::SAML2::Protocol::LogoutRequest->new_from_xml(
+        xml => $xml_text
+);
+ok($soaped_request_text);
+isa_ok($soaped_request_text, 'Net::SAML2::Protocol::LogoutRequest');
+ok($soaped_request_text->session eq $request_text->session);
+ok($soaped_request_text->nameid eq $request_text->nameid);
 
 done_testing;

--- a/t/06-redirect-binding.t
+++ b/t/06-redirect-binding.t
@@ -4,15 +4,19 @@ use warnings;
 use Net::SAML2;
 use MIME::Base64;
 use Data::Dumper;
-use File::Slurp;
+use File::Slurp qw(read_file );
 use LWP::UserAgent;
+
+my $key = 't/sign-nopw-cert.pem';
+my $cert = 't/sign-nopw-cert.pem';
+my $cacert = 't/cacert.pem';
 
 my $sp = Net::SAML2::SP->new(
         id               => 'http://localhost:3000',
         url              => 'http://localhost:3000',
-        key              => 't/sign-nopw-cert.pem',
-        cert             => 't/sign-nopw-cert.pem',
-        cacert           => 't/cacert.pem',
+        key              => $key,
+        cert             => $cert,
+        cacert           => $cacert,
         org_name         => 'Test',
         org_display_name => 'Test',
         org_contact      => 'test@example.com',
@@ -21,11 +25,13 @@ ok($sp);
 
 my $metadata = read_file('t/idp-metadata.xml');
 ok($metadata);
+
 my $idp = Net::SAML2::IdP->new_from_xml( xml => $metadata, cacert => 't/cacert.pem' );
 ok($idp);
 
 my $sso_url = $idp->sso_url($idp->binding('redirect'));
 ok($sso_url);
+
 my $authnreq = $sp->authn_request(
     $idp->entityid,
     $idp->format('persistent'),
@@ -45,5 +51,54 @@ my ($request, $relaystate) = $redirect->verify($location);
 ok($request);
 ok($relaystate);
 ok($relaystate eq 'http://return/url');
+
+# Repeat tests for certs as strings
+my $cert_text = read_file($cert);
+my $key_text = read_file($key);
+my $cacert_text = read_file($cacert);
+
+my $sp_text = Net::SAML2::SP->new(
+        id               => 'http://localhost:3000',
+        url              => 'http://localhost:3000',
+        key              => $key_text,
+        cert             => $cert_text,
+        cacert           => $cacert_text,
+        org_name         => 'Test',
+        org_display_name => 'Test',
+        org_contact      => 'test@example.com',
+        certs_as_string  => 1,
+);
+ok($sp_text);
+
+my $metadata_text = read_file('t/idp-metadata.xml');
+ok($metadata_text);
+my $idp_text = Net::SAML2::IdP->new_from_xml(
+                    xml => $metadata,
+                    cacert => $cacert_text,
+                    certs_as_string => 1 );
+ok($idp_text);
+
+my $sso_url_text = $idp_text->sso_url($idp_text->binding('redirect'));
+ok($sso_url_text);
+
+my $authnreq_text = $sp_text->authn_request(
+    $idp_text->entityid,
+    $idp_text->format('persistent'),
+)->as_xml;
+ok($authnreq_text);
+
+my $redirect_text = $sp_text->sso_redirect_binding($idp_text, 'SAMLRequest');
+ok($redirect_text);
+
+my $location_text = $redirect_text->sign(
+        $authnreq_text,
+        'http://return/url',
+);
+ok($location_text);
+
+my ($request_text, $relaystate_text) = $redirect_text->verify($location_text);
+ok($request_text);
+ok($relaystate_text);
+ok($relaystate_text eq 'http://return/url');
 
 done_testing;

--- a/t/09-authn-request.t
+++ b/t/09-authn-request.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Net::SAML2;
 use Net::SAML2::XML::Sig;
+use File::Slurp qw(read_file);
 
 use Crypt::OpenSSL::Random;
 
@@ -17,7 +18,6 @@ my $ar = Net::SAML2::Protocol::AuthnRequest->new(
 ok($ar);
 my $xml = $ar->as_xml;
 ok($xml);
-#diag($xml);
 like($xml, qr/ID="$request_id"/);
 like($xml, qr/IssueInstant=".+"/);
 
@@ -34,4 +34,24 @@ ok($signed);
 
 my $verify = $signer->verify($signed);
 ok($verify);
+
+my $cert = read_file('t/sign-nopw-cert.pem');
+ok($cert);
+my $key = read_file('t/sign-nopw-cert.pem');
+ok($key);
+my $signer_text = Net::SAML2::XML::Sig->new({
+    canonicalizer => 'XML::CanonicalizeXML',
+    key => $key,
+    cert => $cert,
+    certs_as_string => 1,
+});
+
+ok($signer_text);
+
+# create a signature
+my $signed_text = $signer_text->sign($xml);
+ok($signed_text);
+
+my $verify_text = $signer_text->verify($signed);
+ok($verify_text);
 done_testing;

--- a/t/11-more-metadata.t
+++ b/t/11-more-metadata.t
@@ -2,9 +2,11 @@ use Test::More;
 use Net::SAML2;
 use File::Slurp;
 
+my $cacert = 't/cacert.pem';
+
 my $xml = read_file('t/idp-metadata2.xml');
 
-my $idp = Net::SAML2::IdP->new_from_xml( xml => $xml, cacert => 't/cacert.pem' );
+my $idp = Net::SAML2::IdP->new_from_xml( xml => $xml, cacert => $cacert );
 ok($idp);
 
 ok($idp->sso_url($idp->binding('redirect')));
@@ -13,5 +15,22 @@ ok($idp->art_url($idp->binding('soap')));
 
 ok($idp->cert('signing'));
 ok($idp->entityid eq 'http://sso.dev.venda.com/opensso');
+
+# Repeat Tests for certs as strings
+
+my $cacert_text = read_file($cacert);
+
+my $idp_text = Net::SAML2::IdP->new_from_xml(
+                    xml => $xml,
+                    cacert => $cacert_text,
+                    certs_as_string => 1);
+ok($idp_text);
+
+ok($idp_text->sso_url($idp_text->binding('redirect')));
+ok($idp_text->slo_url($idp_text->binding('redirect')));
+ok($idp_text->art_url($idp_text->binding('soap')));
+
+ok($idp_text->cert('signing'));
+ok($idp_text->entityid eq 'http://sso.dev.venda.com/opensso');
 
 done_testing;


### PR DESCRIPTION
Works the same as 0.20 version and below.  If certs_as_string => 1 is set the keys, certs and cacerts may be passed as strings instead of file names

Fixes #18 